### PR TITLE
Update platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -5,6 +5,7 @@ default_envs = bluepill
 platform = ststm32
 framework = stm32cube
 debug_tool = stlink
+upload_protocol = serial
 
 [env:bluepill]
 board = bluepill_f103c8


### PR DESCRIPTION
added `upload_protocol = serial` (needed for programming via FTDI adapter)